### PR TITLE
Add GoFr Community to Open Source Communities Database

### DIFF
--- a/data/communities.csv
+++ b/data/communities.csv
@@ -62,3 +62,4 @@ name,description,website,region,category,country,city_state,member_count,status,
 "OpenChain China Work Group","OpenChain Project","https://openchainproject.org/participate","Eastern Asia","Others","China",,,"Active","OpenChain Chapter","hybrid"
 "Ubuntu Korea Community","Ubuntu Chapter","https://ubuntu-kr.org","Eastern Asia","Others","South Korea",,,"Active","Ubuntu Chapter","hybrid"
 "Kaiyuanshe Alliance City Communities","Kaiyuanshe","https://kaiyuanshe.cn/community","Eastern Asia","Others","China",,,"Active","Kaiyuanshe City Chapters","hybrid"
+"GoFr Community","Open-source Golang framework for accelerated microservice development","https://gofr.dev/","Southern Asia","Cloud Native","India,Bangalore","11000","Active","CNCF Ecosystem","hybrid"

--- a/data/communities.csv
+++ b/data/communities.csv
@@ -62,5 +62,5 @@ name,description,website,region,category,country,city_state,member_count,status,
 "OpenChain China Work Group","OpenChain Project","https://openchainproject.org/participate","Eastern Asia","Others","China",,,"Active","OpenChain Chapter","hybrid"
 "Ubuntu Korea Community","Ubuntu Chapter","https://ubuntu-kr.org","Eastern Asia","Others","South Korea",,,"Active","Ubuntu Chapter","hybrid"
 "Kaiyuanshe Alliance City Communities","Kaiyuanshe","https://kaiyuanshe.cn/community","Eastern Asia","Others","China",,,"Active","Kaiyuanshe City Chapters","hybrid"
-"GoFr Community","Open-source Golang framework for accelerated microservice development","https://gofr.dev/","Southern Asia","Cloud Native","India,Bangalore","11000","Active","CNCF Ecosystem","hybrid"
+"GoFr Community","Open-source Golang framework for accelerated microservice development","https://gofr.dev/events","Southern Asia","Cloud Native","Bangalore, India","11000","Active",","hybrid"
 "Cloud Native Stockholm","Stockholm Cloud Native Community Group","https://community.cncf.io/cloud-native-stockholm/","Northern Europe","Cloud Native","Sweden","Stockholm","797","Active","CNCF Chapter","In-Person"


### PR DESCRIPTION
This PR adds the GoFr Community to the Open Source Communities Database.

**[GoFr](https://gofr.dev/)** is an open-source Golang framework for building cloud-native microservices. It is listed in the [CNCF Landscape](https://landscape.cncf.io/?group=projects-and-products&view-mode=grid&item=orchestration-management--remote-procedure-call--gofr) under RPC frameworks.

**Community Info:**
- **Name:** GoFr Community
- **Description:** Open-source Golang framework for accelerated microservice development
- **Website:** https://gofr.dev/
- **Region:** Southern Asia
- **Category:** Cloud Native
- **Country/City:** India, Bangalore
- **Member Count:** ~11,000 ([Github Stars](https://github.com/gofr-dev/gofr)+ [Discord](https://discord.gg/mapUrRGT))
- **Status:** Active
- **Type:** CNCF Ecosystem
- **Format:** Hybrid (online + in-person)

Looking forward to the maintainers’ review!
