### PR TITLE
Added Cloud Native Stockholm

### DIFF
--- a/data/communities.csv
+++ b/data/communities.csv
@@ -62,3 +62,4 @@ name,description,website,region,category,country,city_state,member_count,status,
 "OpenChain China Work Group","OpenChain Project","https://openchainproject.org/participate","Eastern Asia","Others","China",,,"Active","OpenChain Chapter","hybrid"
 "Ubuntu Korea Community","Ubuntu Chapter","https://ubuntu-kr.org","Eastern Asia","Others","South Korea",,,"Active","Ubuntu Chapter","hybrid"
 "Kaiyuanshe Alliance City Communities","Kaiyuanshe","https://kaiyuanshe.cn/community","Eastern Asia","Others","China",,,"Active","Kaiyuanshe City Chapters","hybrid"
+"Cloud Native Stockholm","Stockholm Cloud Native Community Group","https://community.cncf.io/cloud-native-stockholm/","Northern Europe","Cloud Native","Sweden","Stockholm","797","Active","CNCF Chapter","In-Person"


### PR DESCRIPTION
The Stockholm Cloud Native Community Group has been added per issue https://github.com/chaoss/oscdb/issues/19